### PR TITLE
Fix problem where the page exists checker didn't got the locale

### DIFF
--- a/src/Checker/PageExistsChecker.php
+++ b/src/Checker/PageExistsChecker.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Setono\SyliusCMSPlugin\Checker;
 
 use Setono\SyliusCMSPlugin\Repository\PageRepositoryInterface;
-use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 final class PageExistsChecker implements PageExistsCheckerInterface
 {
-    private LocaleContextInterface $localeContext;
-
     private PageRepositoryInterface $pageRepository;
 
-    public function __construct(LocaleContextInterface $localeContext, PageRepositoryInterface $pageRepository)
+    public function __construct(PageRepositoryInterface $pageRepository)
     {
-        $this->localeContext = $localeContext;
         $this->pageRepository = $pageRepository;
     }
 
@@ -32,7 +28,10 @@ final class PageExistsChecker implements PageExistsCheckerInterface
             return false;
         }
 
-        return $this->pageRepository->exists($this->localeContext->getLocaleCode(), $slug);
+        // NOTICE: We cannot use the locale to check if the slug exists on the specific locale
+        // because the locale isn't available at this point in time in the request cycle
+
+        return $this->pageRepository->exists($slug);
     }
 
     /**

--- a/src/Doctrine/ORM/PageRepository.php
+++ b/src/Doctrine/ORM/PageRepository.php
@@ -28,13 +28,12 @@ class PageRepository extends EntityRepository implements PageRepositoryInterface
         return $obj;
     }
 
-    public function exists(string $locale, string $slug): bool
+    public function exists(string $slug): bool
     {
         return (int) $this->createQueryBuilder('o')
             ->select('COUNT(o)')
-            ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
+            ->leftJoin('o.translations', 'translation')
             ->andWhere('translation.slug = :slug')
-            ->setParameter('locale', $locale)
             ->setParameter('slug', $slug)
             ->getQuery()
             ->getSingleScalarResult() > 0

--- a/src/Repository/PageRepositoryInterface.php
+++ b/src/Repository/PageRepositoryInterface.php
@@ -17,5 +17,5 @@ interface PageRepositoryInterface extends RepositoryInterface
 {
     public function findOneBySlug(string $locale, string $slug): ?PageInterface;
 
-    public function exists(string $locale, string $slug): bool;
+    public function exists(string $slug): bool;
 }

--- a/src/Resources/config/services/checker.xml
+++ b/src/Resources/config/services/checker.xml
@@ -32,7 +32,6 @@
 
         <!-- Misc -->
         <service id="setono_sylius_cms.checker.page_exists" class="Setono\SyliusCMSPlugin\Checker\PageExistsChecker">
-            <argument type="service" id="sylius.context.locale"/>
             <argument type="service" id="setono_sylius_cms.repository.page"/>
         </service>
     </services>


### PR DESCRIPTION
This PR will remove the locale usage in the page exists checker. This makes the checker less valuable, but it is still very valuable since it still checks if a page exists with a given slug on any locale instead of just allowing _all_ requests to be given to the controller