### PR TITLE
Cache invalidation for blocks, carousel and views

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN set -eux; \
 		zlib-dev \
 	; \
 	\
+	pecl install xdebug; \
 	docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype; \
 	docker-php-ext-configure zip --with-zip; \
 	docker-php-ext-install -j$(nproc) \
@@ -51,6 +52,7 @@ RUN set -eux; \
 	pecl clear-cache; \
 	docker-php-ext-enable \
 		apcu \
+		xdebug \
 		opcache \
 	; \
 	\
@@ -70,7 +72,13 @@ RUN set -eux; \
     \
     sed -i 's/memory_limit = .*/memory_limit = 256M/' /usr/local/etc/php/php.ini; \
     \
-    sed -i 's/memory_limit = .*/memory_limit = -1/' /usr/local/etc/php/php-cli.ini;
+    sed -i 's/memory_limit = .*/memory_limit = -1/' /usr/local/etc/php/php-cli.ini; \
+    \
+    echo "xdebug.mode=debug,trace" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    \
+    echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    \
+    echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
 
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ RUN set -eux; \
 EXPOSE 8080
 WORKDIR /srv/sylius
 
-ARG APP_ENV=test
+ARG APP_ENV=dev
 
 CMD ["symfony", "server:start", "--dir=tests/Application/public", "--port=8080", "--no-tls" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
             - mysql
         ports:
             - "8080:8080"
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
 
     mysql:
         image: percona:5.7

--- a/src/Doctrine/ORM/CarouselRepository.php
+++ b/src/Doctrine/ORM/CarouselRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Setono\SyliusCMSPlugin\Doctrine\ORM;
 
+use Doctrine\ORM\Query\Expr\Join;
 use Setono\SyliusCMSPlugin\Model\CarouselInterface;
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
 use Setono\SyliusCMSPlugin\Repository\CarouselRepositoryInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Webmozart\Assert\Assert;
@@ -20,5 +22,14 @@ class CarouselRepository extends EntityRepository implements CarouselRepositoryI
         Assert::nullOrIsInstanceOf($obj, CarouselInterface::class);
 
         return $obj;
+    }
+
+    public function findByBlock(ElementInterface $element): array
+    {
+        return $this->createQueryBuilder('c')
+            ->innerJoin('c.carouselBlocks', 'cb', Join::WITH, 'cb.block = :element')
+            ->setParameter(':element', $element)
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/src/Doctrine/ORM/ViewRepository.php
+++ b/src/Doctrine/ORM/ViewRepository.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Setono\SyliusCMSPlugin\Doctrine\ORM;
 
+use Doctrine\ORM\Query\Expr\Join;
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
 use Setono\SyliusCMSPlugin\Model\TemplateInterface;
 use Setono\SyliusCMSPlugin\Model\ViewInterface;
 use Setono\SyliusCMSPlugin\Repository\ViewRepositoryInterface;
@@ -35,5 +37,14 @@ class ViewRepository extends EntityRepository implements ViewRepositoryInterface
         Assert::allIsInstanceOf($views, ViewInterface::class);
 
         return $views;
+    }
+
+    public function findByBlock(ElementInterface $element): array
+    {
+        return $this->createQueryBuilder('v')
+            ->innerJoin('v.viewBlocks', 'vb', Join::WITH, 'vb.block = :element')
+            ->setParameter(':element', $element)
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/src/EventListener/CarouselCacheInvalidatorListener.php
+++ b/src/EventListener/CarouselCacheInvalidatorListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\EventListener;
+
+use Setono\SyliusCMSPlugin\Generator\ElementCacheKeyGeneratorInterface;
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
+use Setono\SyliusCMSPlugin\Repository\CarouselRepositoryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class CarouselCacheInvalidatorListener
+{
+    private CacheInterface $cachePool;
+    private ElementCacheKeyGeneratorInterface $elementCacheKeyProvider;
+    private CarouselRepositoryInterface $repository;
+
+    public function __construct(
+        CacheInterface $cachePool,
+        ElementCacheKeyGeneratorInterface $elementCacheKeyProvider,
+        CarouselRepositoryInterface $repository
+    )
+    {
+        $this->cachePool = $cachePool;
+        $this->elementCacheKeyProvider = $elementCacheKeyProvider;
+        $this->repository = $repository;
+    }
+
+    public function invalidateCache(GenericEvent $event): void
+    {
+        /** @var ElementInterface $block */
+        $element = $event->getSubject();
+
+        $carousels = $this->repository->findByBlock($element);
+
+        if (count($carousels) > 0) {
+            foreach ($carousels as $carousel) {
+                $cacheKey = $this->elementCacheKeyProvider->generateCacheKey($carousel, get_class($carousel));
+                try {
+                    $this->cachePool->delete($cacheKey);
+                } catch (\Throwable $e) {
+                    // Ignore because it means the cache does not exist yet
+                }
+            }
+        }
+    }
+}

--- a/src/EventListener/Doctrine/GenericElementCacheInvalidatorListener.php
+++ b/src/EventListener/Doctrine/GenericElementCacheInvalidatorListener.php
@@ -43,7 +43,7 @@ final class GenericElementCacheInvalidatorListener
 
     private function invalidateCache(ElementInterface $element): void
     {
-        $cacheKey = $this->elementCacheKeyProvider->generateCacheKey($element);
+        $cacheKey = $this->elementCacheKeyProvider->generateCacheKey($element, get_class($element));
 
         try {
             $this->cachePool->delete($cacheKey);

--- a/src/EventListener/Doctrine/GenericElementCacheInvalidatorListener.php
+++ b/src/EventListener/Doctrine/GenericElementCacheInvalidatorListener.php
@@ -7,6 +7,8 @@ namespace Setono\SyliusCMSPlugin\EventListener\Doctrine;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Setono\SyliusCMSPlugin\Generator\ElementCacheKeyGeneratorInterface;
 use Setono\SyliusCMSPlugin\Model\ElementInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Contracts\Cache\CacheInterface;
 
 final class GenericElementCacheInvalidatorListener
@@ -14,11 +16,16 @@ final class GenericElementCacheInvalidatorListener
     private CacheInterface $cachePool;
 
     private ElementCacheKeyGeneratorInterface $elementCacheKeyProvider;
+    private EventDispatcherInterface $eventDispatcher;
 
-    public function __construct(CacheInterface $cachePool, ElementCacheKeyGeneratorInterface $elementCacheKeyProvider)
-    {
+    public function __construct(
+        CacheInterface $cachePool,
+        ElementCacheKeyGeneratorInterface $elementCacheKeyProvider,
+        EventDispatcherInterface $eventDispatcher
+    ) {
         $this->cachePool = $cachePool;
         $this->elementCacheKeyProvider = $elementCacheKeyProvider;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function postPersist(LifecycleEventArgs $args): void
@@ -50,5 +57,7 @@ final class GenericElementCacheInvalidatorListener
         } catch (\Throwable $e) {
             // Ignore because it means the cache does not exist yet
         }
+
+        $this->eventDispatcher->dispatch(new GenericEvent($element), 'setono_sylius_cms.block.cache_invalidated');
     }
 }

--- a/src/EventListener/ViewCacheInvalidatorListener.php
+++ b/src/EventListener/ViewCacheInvalidatorListener.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\EventListener;
+
+use Setono\SyliusCMSPlugin\Generator\ElementCacheKeyGeneratorInterface;
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
+use Setono\SyliusCMSPlugin\Repository\CarouselRepositoryInterface;
+use Setono\SyliusCMSPlugin\Repository\ViewRepositoryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class ViewCacheInvalidatorListener
+{
+    private CacheInterface $cachePool;
+    private ElementCacheKeyGeneratorInterface $elementCacheKeyProvider;
+    private ViewRepositoryInterface $repository;
+
+    public function __construct(
+        CacheInterface $cachePool,
+        ElementCacheKeyGeneratorInterface $elementCacheKeyProvider,
+        ViewRepositoryInterface $repository
+    )
+    {
+        $this->cachePool = $cachePool;
+        $this->elementCacheKeyProvider = $elementCacheKeyProvider;
+        $this->repository = $repository;
+    }
+
+    public function invalidateCache(GenericEvent $event): void
+    {
+        /** @var ElementInterface $block */
+        $element = $event->getSubject();
+
+        $view = $this->repository->findByBlock($element);
+
+        if (count($view) > 0) {
+            foreach ($view as $carousel) {
+                $cacheKey = $this->elementCacheKeyProvider->generateCacheKey($carousel, get_class($carousel));
+                try {
+                    $this->cachePool->delete($cacheKey);
+                } catch (\Throwable $e) {
+                    // Ignore because it means the cache does not exist yet
+                }
+            }
+        }
+    }
+}

--- a/src/Repository/CarouselRepositoryInterface.php
+++ b/src/Repository/CarouselRepositoryInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Setono\SyliusCMSPlugin\Repository;
 
+use Setono\SyliusCMSPlugin\Model\Carousel;
 use Setono\SyliusCMSPlugin\Model\CarouselInterface;
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 /**
@@ -16,4 +18,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 interface CarouselRepositoryInterface extends RepositoryInterface
 {
     public function findOneByCode(string $code): ?CarouselInterface;
+
+    /** @return list<int, Carousel> */
+    public function findByBlock(ElementInterface $element): array;
 }

--- a/src/Repository/ViewRepositoryInterface.php
+++ b/src/Repository/ViewRepositoryInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Setono\SyliusCMSPlugin\Repository;
 
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
 use Setono\SyliusCMSPlugin\Model\TemplateInterface;
+use Setono\SyliusCMSPlugin\Model\View;
 use Setono\SyliusCMSPlugin\Model\ViewInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
@@ -22,4 +24,8 @@ interface ViewRepositoryInterface extends RepositoryInterface
      * @return ViewInterface[]
      */
     public function findByTemplate(TemplateInterface $template): array;
+
+
+    /** @return list<int, View> */
+    public function findByBlock(ElementInterface $element): array;
 }


### PR DESCRIPTION
This is the initial implementation, what do you think? It's a draft for now, want some feedback.

The idea is that I'm throwing an event in the block invalidator and listen for that event in other event listeners for Carousel and Views that know how to check if they are affected by a block change and then cache gets reset.

TODO:
* Add functionality to the listeners so they can also listen for the doctrine events on Carousel and View entities so it also updates their cache, so a bit of refactoring and configuration.

Took me about an 1.5 hours to design and implement this (did a few iterations) and about 30 mins for those Docker changes to implement and test and make PHPStorm work with it all.