### PR TITLE
Add tags to elements

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusCMSPlugin\DependencyInjection;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\BlockRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\CarouselRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\PageRepository;
+use Setono\SyliusCMSPlugin\Doctrine\ORM\TagRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\TemplateRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\ViewRepository;
 use Setono\SyliusCMSPlugin\Form\Type\AssetType;
@@ -25,6 +26,7 @@ use Setono\SyliusCMSPlugin\Model\Carousel;
 use Setono\SyliusCMSPlugin\Model\CarouselBlock;
 use Setono\SyliusCMSPlugin\Model\Page;
 use Setono\SyliusCMSPlugin\Model\PageTranslation;
+use Setono\SyliusCMSPlugin\Model\Tag;
 use Setono\SyliusCMSPlugin\Model\Template;
 use Setono\SyliusCMSPlugin\Model\View;
 use Setono\SyliusCMSPlugin\Model\ViewBlock;
@@ -190,6 +192,22 @@ final class Configuration implements ConfigurationInterface
                                                 ->scalarNode('factory')->defaultValue(TranslatableFactory::class)->end()
                                             ->end()
                                         ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('tag')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(Tag::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->defaultValue(TagRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('form')->defaultValue(DefaultResourceType::class)->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Doctrine/ORM/TagRepository.php
+++ b/src/Doctrine/ORM/TagRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Doctrine\ORM;
+
+use Setono\SyliusCMSPlugin\Model\TagInterface;
+use Setono\SyliusCMSPlugin\Repository\TagRepositoryInterface;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Webmozart\Assert\Assert;
+
+class TagRepository extends EntityRepository implements TagRepositoryInterface
+{
+    public function findByCodePart(?string $phrase, ?int $limit = null): array
+    {
+        if (null === $phrase) {
+            return [];
+        }
+
+        $tags = $this->createQueryBuilder('o')
+            ->andWhere('o.code LIKE :code')
+            ->setParameter('code', '%' . $phrase . '%')
+            ->setMaxResults($limit ?? 25)
+            ->getQuery()
+            ->getResult()
+        ;
+
+        Assert::allIsInstanceOf($tags, TagInterface::class);
+
+        return $tags;
+    }
+}

--- a/src/Form/Type/BlockType.php
+++ b/src/Form/Type/BlockType.php
@@ -56,6 +56,10 @@ final class BlockType extends AbstractResourceType
                 'label' => 'setono_sylius_cms.form.internal_description',
                 'required' => false,
             ])
+            ->add('tags', TagAutocompleteChoiceType::class, [
+                'label' => 'setono_sylius_cms.ui.tags',
+                'multiple' => true,
+            ])
             ->addEventSubscriber(new ConvertRawContentSubscriber(
                 $this->parser,
                 $this->renderer,

--- a/src/Form/Type/TagAutocompleteChoiceType.php
+++ b/src/Form/Type/TagAutocompleteChoiceType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Form\Type;
+
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class TagAutocompleteChoiceType extends AbstractType
+{
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'resource' => 'setono_sylius_cms.tag',
+            'choice_name' => 'code',
+            'choice_value' => 'code',
+        ]);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['remote_criteria_type'] = 'contains';
+        $view->vars['remote_criteria_name'] = 'phrase';
+        $view->vars['remote_url'] = $this->urlGenerator->generate('setono_sylius_cms_admin_ajax_tag_by_code_phrase');
+        $view->vars['load_edit_url'] = $this->urlGenerator->generate('setono_sylius_cms_admin_ajax_tag_by_code_phrase');
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'setono_sylius_cms_tag_autocomplete_choice';
+    }
+
+    public function getParent(): string
+    {
+        return ResourceAutocompleteChoiceType::class;
+    }
+}

--- a/src/Model/Asset.php
+++ b/src/Model/Asset.php
@@ -6,20 +6,15 @@ namespace Setono\SyliusCMSPlugin\Model;
 
 class Asset implements AssetInterface
 {
-    use InternalDescriptionAwareTrait;
+    use IdAwareTrait;
 
-    protected ?int $id = null;
+    use InternalDescriptionAwareTrait;
 
     protected ?string $name = null;
 
     protected ?string $path = null;
 
     protected ?string $mimeType = null;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getName(): ?string
     {

--- a/src/Model/AssetInterface.php
+++ b/src/Model/AssetInterface.php
@@ -6,10 +6,8 @@ namespace Setono\SyliusCMSPlugin\Model;
 
 use Sylius\Component\Resource\Model\ResourceInterface;
 
-interface AssetInterface extends ResourceInterface, InternalDescriptionAwareInterface
+interface AssetInterface extends IdAwareInterface, ResourceInterface, InternalDescriptionAwareInterface
 {
-    public function getId(): ?int;
-
     public function getName(): ?string;
 
     public function setName(string $name): void;

--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -21,6 +21,8 @@ class Block extends Element implements BlockInterface
 
     public function __construct()
     {
+        parent::__construct();
+
         $this->initializeTranslationsCollection();
     }
 

--- a/src/Model/BlockTranslation.php
+++ b/src/Model/BlockTranslation.php
@@ -8,16 +8,11 @@ use Sylius\Component\Resource\Model\AbstractTranslation;
 
 class BlockTranslation extends AbstractTranslation implements BlockTranslationInterface
 {
-    protected ?int $id = null;
+    use IdAwareTrait;
 
     protected ?string $content = null;
 
     protected ?string $rawContent = null;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getContent(): ?string
     {

--- a/src/Model/BlockTranslationInterface.php
+++ b/src/Model/BlockTranslationInterface.php
@@ -7,10 +7,8 @@ namespace Setono\SyliusCMSPlugin\Model;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TranslationInterface;
 
-interface BlockTranslationInterface extends ResourceInterface, TranslationInterface
+interface BlockTranslationInterface extends IdAwareInterface, ResourceInterface, TranslationInterface
 {
-    public function getId(): ?int;
-
     public function getContent(): ?string;
 
     public function setContent(?string $content): void;

--- a/src/Model/Carousel.php
+++ b/src/Model/Carousel.php
@@ -22,6 +22,8 @@ class Carousel extends Element implements CarouselInterface
 
     public function __construct()
     {
+        parent::__construct();
+
         $this->carouselBlocks = new ArrayCollection();
     }
 

--- a/src/Model/CarouselBlock.php
+++ b/src/Model/CarouselBlock.php
@@ -6,18 +6,13 @@ namespace Setono\SyliusCMSPlugin\Model;
 
 class CarouselBlock implements CarouselBlockInterface
 {
-    protected ?int $id = null;
+    use IdAwareTrait;
 
     protected int $position = 0;
 
     protected ?CarouselInterface $carousel = null;
 
     protected ?BlockInterface $block = null;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getPosition(): int
     {

--- a/src/Model/CodeAwareTrait.php
+++ b/src/Model/CodeAwareTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+trait CodeAwareTrait
+{
+    protected ?string $code = null;
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(?string $code): void
+    {
+        $this->code = $code;
+    }
+}

--- a/src/Model/Element.php
+++ b/src/Model/Element.php
@@ -8,13 +8,22 @@ use Sylius\Component\Resource\Model\TimestampableTrait;
 
 abstract class Element implements ElementInterface
 {
+    use CodeAwareTrait;
+
+    use IdAwareTrait;
+
     use InternalDescriptionAwareTrait;
+
+    use TagsAwareTrait {
+        __construct as private initializeTagsCollection;
+    }
 
     use TimestampableTrait;
 
-    protected ?int $id = null;
-
-    protected ?string $code = null;
+    public function __construct()
+    {
+        $this->initializeTagsCollection();
+    }
 
     /**
      * @return list<string>
@@ -27,21 +36,6 @@ abstract class Element implements ElementInterface
             self::TYPE_PAGE,
             self::TYPE_VIEW,
         ];
-    }
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
-
-    public function getCode(): ?string
-    {
-        return $this->code;
-    }
-
-    public function setCode(?string $code): void
-    {
-        $this->code = $code;
     }
 
     public function getIdentifier(): string

--- a/src/Model/ElementInterface.php
+++ b/src/Model/ElementInterface.php
@@ -8,7 +8,13 @@ use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
-interface ElementInterface extends CodeAwareInterface, InternalDescriptionAwareInterface, ResourceInterface, TimestampableInterface
+interface ElementInterface extends
+    CodeAwareInterface,
+    IdAwareInterface,
+    InternalDescriptionAwareInterface,
+    ResourceInterface,
+    TagsAwareInterface,
+    TimestampableInterface
 {
     public const TYPE_BLOCK = 'block';
 
@@ -17,8 +23,6 @@ interface ElementInterface extends CodeAwareInterface, InternalDescriptionAwareI
     public const TYPE_PAGE = 'page';
 
     public const TYPE_VIEW = 'view';
-
-    public function getId(): ?int;
 
     public function getType(): string;
 

--- a/src/Model/IdAwareInterface.php
+++ b/src/Model/IdAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+interface IdAwareInterface
+{
+    public function getId(): ?int;
+}

--- a/src/Model/IdAwareTrait.php
+++ b/src/Model/IdAwareTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+trait IdAwareTrait
+{
+    protected ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -34,6 +34,8 @@ class Page extends Element implements PageInterface
 
     public function __construct()
     {
+        parent::__construct();
+
         $this->channels = new ArrayCollection();
         $this->initializeTranslationsCollection();
     }

--- a/src/Model/PageTranslation.php
+++ b/src/Model/PageTranslation.php
@@ -8,18 +8,13 @@ use Sylius\Component\Resource\Model\AbstractTranslation;
 
 class PageTranslation extends AbstractTranslation implements PageTranslationInterface
 {
-    protected ?int $id = null;
+    use IdAwareTrait;
 
     protected ?string $slug = null;
 
     protected ?string $title = null;
 
     protected ?string $metaDescription = null;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getSlug(): ?string
     {

--- a/src/Model/PageTranslationInterface.php
+++ b/src/Model/PageTranslationInterface.php
@@ -8,10 +8,8 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\SlugAwareInterface;
 use Sylius\Component\Resource\Model\TranslationInterface;
 
-interface PageTranslationInterface extends ResourceInterface, TranslationInterface, SlugAwareInterface
+interface PageTranslationInterface extends IdAwareInterface, ResourceInterface, TranslationInterface, SlugAwareInterface
 {
-    public function getId(): ?int;
-
     public function getSlug(): ?string;
 
     public function setSlug(?string $slug): void;

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+class Tag implements TagInterface
+{
+    use CodeAwareTrait;
+
+    use IdAwareTrait;
+}

--- a/src/Model/TagInterface.php
+++ b/src/Model/TagInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+use Sylius\Component\Resource\Model\CodeAwareInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+interface TagInterface extends CodeAwareInterface, IdAwareInterface, ResourceInterface
+{
+}

--- a/src/Model/TagsAwareInterface.php
+++ b/src/Model/TagsAwareInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+use Doctrine\Common\Collections\Collection;
+
+interface TagsAwareInterface
+{
+    /**
+     * @return Collection|TagInterface[]
+     *
+     * @psalm-return Collection<array-key, TagInterface>
+     */
+    public function getTags(): Collection;
+
+    public function addTag(TagInterface $tag): void;
+
+    public function removeTag(TagInterface $tag): void;
+
+    /**
+     * Returns true if the tag is already present
+     */
+    public function hasTag(TagInterface $tag): bool;
+}

--- a/src/Model/TagsAwareTrait.php
+++ b/src/Model/TagsAwareTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+trait TagsAwareTrait
+{
+    /**
+     * @var Collection|TagInterface[]
+     *
+     * @psalm-var Collection<array-key, TagInterface>
+     */
+    protected Collection $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection|TagInterface[]
+     *
+     * @psalm-return Collection<array-key, TagInterface>
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(TagInterface $tag): void
+    {
+        if (!$this->hasTag($tag)) {
+            $this->tags->add($tag);
+        }
+    }
+
+    public function removeTag(TagInterface $tag): void
+    {
+        if ($this->hasTag($tag)) {
+            $this->tags->removeElement($tag);
+        }
+    }
+
+    /**
+     * Returns true if the tag is already present
+     */
+    public function hasTag(TagInterface $tag): bool
+    {
+        return $this->tags->contains($tag);
+    }
+}

--- a/src/Model/Template.php
+++ b/src/Model/Template.php
@@ -8,11 +8,13 @@ use Sylius\Component\Resource\Model\TimestampableTrait;
 
 class Template implements TemplateInterface
 {
-    use TimestampableTrait;
+    use CodeAwareTrait;
+
+    use IdAwareTrait;
 
     use InternalDescriptionAwareTrait;
 
-    protected ?int $id = null;
+    use TimestampableTrait;
 
     protected ?string $code = null;
 
@@ -20,21 +22,6 @@ class Template implements TemplateInterface
 
     /** @var list<string> */
     protected array $sections = [];
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
-
-    public function getCode(): ?string
-    {
-        return $this->code;
-    }
-
-    public function setCode(?string $code): void
-    {
-        $this->code = $code;
-    }
 
     public function getSource(): ?string
     {

--- a/src/Model/TemplateInterface.php
+++ b/src/Model/TemplateInterface.php
@@ -10,12 +10,11 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
 
 interface TemplateInterface extends
     CodeAwareInterface,
+    IdAwareInterface,
     InternalDescriptionAwareInterface,
     ResourceInterface,
     TimestampableInterface
 {
-    public function getId(): ?int;
-
     /**
      * This is the Twig source code of the template
      */

--- a/src/Model/View.php
+++ b/src/Model/View.php
@@ -18,6 +18,8 @@ class View extends Element implements ViewInterface
 
     public function __construct()
     {
+        parent::__construct();
+
         $this->viewBlocks = new ArrayCollection();
     }
 

--- a/src/Model/ViewBlock.php
+++ b/src/Model/ViewBlock.php
@@ -6,7 +6,7 @@ namespace Setono\SyliusCMSPlugin\Model;
 
 class ViewBlock implements ViewBlockInterface
 {
-    protected ?int $id = null;
+    use IdAwareTrait;
 
     protected ?ViewInterface $view = null;
 
@@ -15,11 +15,6 @@ class ViewBlock implements ViewBlockInterface
     protected ?string $section = null;
 
     protected int $position = 0;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
 
     public function getView(): ?ViewInterface
     {

--- a/src/Model/ViewBlockInterface.php
+++ b/src/Model/ViewBlockInterface.php
@@ -6,10 +6,8 @@ namespace Setono\SyliusCMSPlugin\Model;
 
 use Sylius\Component\Resource\Model\ResourceInterface;
 
-interface ViewBlockInterface extends ResourceInterface
+interface ViewBlockInterface extends IdAwareInterface, ResourceInterface
 {
-    public function getId(): ?int;
-
     public function getView(): ?ViewInterface;
 
     public function setView(?ViewInterface $view): void;

--- a/src/Repository/TagRepositoryInterface.php
+++ b/src/Repository/TagRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Repository;
+
+use Setono\SyliusCMSPlugin\Model\TagInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/**
+ * @method TagInterface|null find($id, $lockMode = null, $lockVersion = null)
+ * @method TagInterface|null findOneBy(array $criteria, array $orderBy = null)
+ * @method TagInterface[]    findAll()
+ * @method TagInterface[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+interface TagRepositoryInterface extends RepositoryInterface
+{
+    /**
+     * @return array<array-key, TagInterface>
+     */
+    public function findByCodePart(?string $phrase, ?int $limit = null): array;
+}

--- a/src/Resources/config/doctrine/model/Block.orm.xml
+++ b/src/Resources/config/doctrine/model/Block.orm.xml
@@ -24,6 +24,17 @@
             <gedmo:timestampable on="update"/>
         </field>
 
+        <many-to-many field="tags" target-entity="Setono\SyliusCMSPlugin\Model\TagInterface" fetch="EXTRA_LAZY">
+            <join-table name="setono_sylius_cms__block_tags">
+                <join-columns>
+                    <join-column name="block_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="tag_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
         <unique-constraints>
             <unique-constraint columns="code"/>
         </unique-constraints>

--- a/src/Resources/config/doctrine/model/Carousel.orm.xml
+++ b/src/Resources/config/doctrine/model/Carousel.orm.xml
@@ -34,6 +34,17 @@
             </order-by>
         </one-to-many>
 
+        <many-to-many field="tags" target-entity="Setono\SyliusCMSPlugin\Model\TagInterface" fetch="EXTRA_LAZY">
+            <join-table name="setono_sylius_cms__carousel_tags">
+                <join-columns>
+                    <join-column name="carousel_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="tag_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
         <unique-constraints>
             <unique-constraint columns="code"/>
         </unique-constraints>

--- a/src/Resources/config/doctrine/model/Page.orm.xml
+++ b/src/Resources/config/doctrine/model/Page.orm.xml
@@ -40,6 +40,17 @@
             </join-table>
         </many-to-many>
 
+        <many-to-many field="tags" target-entity="Setono\SyliusCMSPlugin\Model\TagInterface" fetch="EXTRA_LAZY">
+            <join-table name="setono_sylius_cms__page_tags">
+                <join-columns>
+                    <join-column name="page_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="tag_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
         <unique-constraints>
             <unique-constraint columns="code"/>
         </unique-constraints>

--- a/src/Resources/config/doctrine/model/Tag.orm.xml
+++ b/src/Resources/config/doctrine/model/Tag.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <mapped-superclass name="Setono\SyliusCMSPlugin\Model\Tag"
+                       table="setono_sylius_cms__tag">
+        <id name="id" type="integer">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="code" column="code" type="string"/>
+
+        <unique-constraints>
+            <unique-constraint columns="code"/>
+        </unique-constraints>
+    </mapped-superclass>
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/model/View.orm.xml
+++ b/src/Resources/config/doctrine/model/View.orm.xml
@@ -34,6 +34,17 @@
             </order-by>
         </one-to-many>
 
+        <many-to-many field="tags" target-entity="Setono\SyliusCMSPlugin\Model\TagInterface" fetch="EXTRA_LAZY">
+            <join-table name="setono_sylius_cms__view_tags">
+                <join-columns>
+                    <join-column name="view_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="tag_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
         <unique-constraints>
             <unique-constraint columns="code"/>
         </unique-constraints>

--- a/src/Resources/config/routes/admin/ajax.yaml
+++ b/src/Resources/config/routes/admin/ajax.yaml
@@ -25,3 +25,32 @@ setono_sylius_cms_admin_ajax_block_by_code_phrase:
                 arguments:
                     phrase: $phrase
                     limit: 25
+
+setono_sylius_cms_admin_ajax_tag_by_code:
+    path: /tags/by-code
+    methods: [GET]
+    defaults:
+        _controller: setono_sylius_cms.controller.tag::indexAction
+        _format: json
+        _sylius:
+            serialization_groups: [Autocomplete]
+            permission: true
+            repository:
+                method: findBy
+                arguments: [code: $code]
+
+setono_sylius_cms_admin_ajax_tag_by_code_phrase:
+    path: /tags/search
+    methods: [GET]
+    defaults:
+        _controller: setono_sylius_cms.controller.tag:indexAction
+        _format: json
+        _sylius:
+            serialization_groups: [Autocomplete]
+            permission: true
+            repository:
+                method: findByCodePart
+                arguments:
+                    phrase: $phrase
+                    locale: null
+                    limit: 25

--- a/src/Resources/config/serializer/Model.Tag.yaml
+++ b/src/Resources/config/serializer/Model.Tag.yaml
@@ -1,0 +1,14 @@
+Setono\SyliusCMSPlugin\Model\Tag:
+    exclusion_policy: ALL
+    xml_root_name: tag
+    properties:
+        id:
+            expose: true
+            type: integer
+            xml_attribute: true
+            groups: [Default, Autocomplete]
+        code:
+            expose: true
+            type: string
+            xml_attribute: true
+            groups: [Default, Autocomplete]

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -174,6 +174,14 @@
             <tag name="form.type"/>
         </service>
 
+        <!-- Tag autocomplete -->
+        <service id="setono_sylius_cms.form.type.tag_autocomplete_choice"
+                 class="Setono\SyliusCMSPlugin\Form\Type\TagAutocompleteChoiceType">
+            <argument type="service" id="router"/>
+
+            <tag name="form.type"/>
+        </service>
+
         <!-- Data mapper -->
         <service id="setono_sylius_cms.form.data_mapper.view_sections"
                  class="Setono\SyliusCMSPlugin\Form\DataMapper\ViewSectionsDataMapper">

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -64,6 +64,7 @@ setono_sylius_cms:
         page_subheader: Manage your CMS pages
         pages: Pages
         preview: Preview
+        tags: Tags
         template: Template
         template_header: Templates
         template_subheader: Manage your templates

--- a/src/Resources/views/admin/block/_form.html.twig
+++ b/src/Resources/views/admin/block/_form.html.twig
@@ -19,6 +19,7 @@
         <div class="ui segment">
             {{ form_row(form.code) }}
             {{ form_row(form.internalDescription) }}
+            {{ form_row(form.tags) }}
             {% set max_upload_size = sscms_max_upload_size() %}
             {% if max_upload_size <= 100 * 1024 * 1024 %}
                 <div class="ui info message">

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -10,6 +10,7 @@ use Setono\SyliusCMSPlugin\DependencyInjection\Configuration;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\BlockRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\CarouselRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\PageRepository;
+use Setono\SyliusCMSPlugin\Doctrine\ORM\TagRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\TemplateRepository;
 use Setono\SyliusCMSPlugin\Doctrine\ORM\ViewRepository;
 use Setono\SyliusCMSPlugin\Form\Type\AssetType;
@@ -28,6 +29,7 @@ use Setono\SyliusCMSPlugin\Model\Carousel;
 use Setono\SyliusCMSPlugin\Model\CarouselBlock;
 use Setono\SyliusCMSPlugin\Model\Page;
 use Setono\SyliusCMSPlugin\Model\PageTranslation;
+use Setono\SyliusCMSPlugin\Model\Tag;
 use Setono\SyliusCMSPlugin\Model\Template;
 use Setono\SyliusCMSPlugin\Model\View;
 use Setono\SyliusCMSPlugin\Model\ViewBlock;
@@ -98,6 +100,15 @@ final class ConfigurationTest extends TestCase
                             'form' => PageTranslationType::class,
                             'factory' => TranslatableFactory::class,
                         ],
+                    ],
+                ],
+                'tag' => [
+                    'classes' => [
+                        'model' => Tag::class,
+                        'controller' => ResourceController::class,
+                        'repository' => TagRepository::class,
+                        'form' => DefaultResourceType::class,
+                        'factory' => Factory::class,
                     ],
                 ],
                 'template' => [


### PR DESCRIPTION
Fixes #138 

- [ ] Must be able to add tags with an autocomplete type like the one used under Sylius promotions
- [ ] Must be able to filter in the backend based on tags

In the future this PR will allow functionality like:

- Output all elements (i.e. blocks) with tag `footer`
- Adding blocks to views by tag instead of static adds which effectively will make sections more dynamic