### PR TITLE
Render assets in Twig

### DIFF
--- a/src/Generator/Twig/AssetTwigGenerator.php
+++ b/src/Generator/Twig/AssetTwigGenerator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Generator\Twig;
+
+use Setono\SyliusCMSPlugin\Model\AssetInterface;
+use Setono\SyliusCMSPlugin\Model\ElementInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @implements TwigGeneratorInterface<AssetInterface>
+ */
+final class AssetTwigGenerator implements TwigGeneratorInterface
+{
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * @param AssetInterface $element
+     */
+    public function generate(ElementInterface $element, array $context = []): string
+    {
+        if (strpos((string) $element->getMimeType(), 'image') !== 0) {
+            return '';
+        }
+
+        return sprintf(
+            '{%% import "@SetonoSyliusCMSPlugin/asset.html.twig" as asset %%}{{ asset.image("%s", "%s", "%s") }}{%% do sscms_push_to_element_stack(%d, "%s", "%s", "%s") %%}',
+            $this->urlGenerator->generate('setono_sylius_cms_view_asset', ['id' => $element->getId()]),
+            $element->getIdentifier(),
+            (string) $element->getName(),
+            (int) $element->getId(),
+            (string) $element->getCode(),
+            $element->getIdentifier(),
+            $element->getType()
+        );
+    }
+}

--- a/src/Resources/config/services/generator.xml
+++ b/src/Resources/config/services/generator.xml
@@ -13,6 +13,11 @@
                  alias="setono_sylius_cms.generator.page.preview_link"/>
 
         <!-- Twig generators -->
+        <service id="setono_sylius_cms.generator.twig.asset"
+                 class="Setono\SyliusCMSPlugin\Generator\Twig\AssetTwigGenerator">
+            <argument type="service" id="router"/>
+        </service>
+
         <service id="setono_sylius_cms.generator.twig.block"
                  class="Setono\SyliusCMSPlugin\Generator\Twig\BlockTwigGenerator"/>
 

--- a/src/Resources/config/services/twig.xml
+++ b/src/Resources/config/services/twig.xml
@@ -36,6 +36,15 @@
         </service>
 
         <!-- Element loaders -->
+        <service id="setono_sylius_cms.twig.loader.element_loader.asset"
+                 class="Setono\SyliusCMSPlugin\Twig\Loader\GenericElementLoader">
+            <argument type="service" id="setono_sylius_cms.repository.asset"/>
+            <argument type="service" id="setono_sylius_cms.generator.twig.asset"/>
+            <argument>asset</argument>
+
+            <tag name="twig.loader"/>
+        </service>
+
         <service id="setono_sylius_cms.twig.loader.element_loader.block"
                  class="Setono\SyliusCMSPlugin\Twig\Loader\GenericElementLoader">
             <argument type="service" id="setono_sylius_cms.repository.block"/>

--- a/src/Resources/views/asset.html.twig
+++ b/src/Resources/views/asset.html.twig
@@ -1,0 +1,3 @@
+{% macro image(src, identifier, alt) %}
+    <img src="{{ src }}" alt="{{ alt }}" class="sscms-asset {{ identifier }}">
+{% endmacro %}

--- a/src/Resources/views/toolbar.html.twig
+++ b/src/Resources/views/toolbar.html.twig
@@ -174,6 +174,20 @@
         </div>
     </div>
 
+    {% if elements.assets is not empty %}
+        <div class="sscms-subheader">{{ 'setono_sylius_cms.ui.assets'|trans }}</div>
+        <ul>
+            {% for element in elements.assets %}
+                <li>
+                    <a href="{{ path('setono_sylius_cms_admin_asset_update', {'id': element.id}) }}"
+                       data-identifier="{{ element.identifier }}" target="_blank">
+                        {{ element.code }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
     {% if elements.blocks is not empty %}
         <div class="sscms-subheader">{{ 'setono_sylius_cms.ui.blocks'|trans }}</div>
         <ul>

--- a/src/Stack/ElementId.php
+++ b/src/Stack/ElementId.php
@@ -28,6 +28,11 @@ final class ElementId
         $this->type = $type;
     }
 
+    public function isAsset(): bool
+    {
+        return ElementInterface::TYPE_ASSET === $this->type;
+    }
+
     public function isBlock(): bool
     {
         return ElementInterface::TYPE_BLOCK === $this->type;

--- a/src/Stack/ElementStack.php
+++ b/src/Stack/ElementStack.php
@@ -36,6 +36,13 @@ final class ElementStack implements ElementStackInterface, \IteratorAggregate
         return !$this->isEmpty();
     }
 
+    public function getAssets(): array
+    {
+        return array_filter($this->elements, static function (ElementId $element): bool {
+            return $element->isAsset();
+        });
+    }
+
     public function getBlocks(): array
     {
         return array_filter($this->elements, static function (ElementId $element): bool {

--- a/src/Stack/ElementStackInterface.php
+++ b/src/Stack/ElementStackInterface.php
@@ -23,6 +23,11 @@ interface ElementStackInterface extends \Traversable, \Countable
     /**
      * @return array<array-key, ElementId>
      */
+    public function getAssets(): array;
+
+    /**
+     * @return array<array-key, ElementId>
+     */
     public function getBlocks(): array;
 
     /**

--- a/src/Twig/Extension/Extension.php
+++ b/src/Twig/Extension/Extension.php
@@ -12,9 +12,10 @@ final class Extension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
+            new TwigFunction('sscms_asset', [Runtime::class, 'asset'], ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
             new TwigFunction('sscms_block', [Runtime::class, 'block'], ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
-            new TwigFunction('sscms_view', [Runtime::class, 'view'], ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
             new TwigFunction('sscms_carousel', [Runtime::class, 'carousel'], ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
+            new TwigFunction('sscms_view', [Runtime::class, 'view'], ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
 
             new TwigFunction('sscms_link_route', [Runtime::class, 'linkToRoute'], ['is_safe' => ['html']]),
             new TwigFunction('sscms_link_resource', [Runtime::class, 'linkToResource'], ['is_safe' => ['html']]),

--- a/src/Twig/Extension/Runtime.php
+++ b/src/Twig/Extension/Runtime.php
@@ -60,19 +60,24 @@ final class Runtime implements RuntimeExtensionInterface, LoggerAwareInterface
         $this->elementStack = $elementStack;
     }
 
+    public function asset(Environment $env, array $context, ?string $block, array $variables = []): string
+    {
+        return $this->renderElement($env, $context, $block, ElementInterface::TYPE_ASSET, $variables);
+    }
+
     public function block(Environment $env, array $context, ?string $block, array $variables = []): string
     {
         return $this->renderElement($env, $context, $block, ElementInterface::TYPE_BLOCK, $variables);
     }
 
-    public function view(Environment $env, array $context, ?string $view, array $variables = []): string
-    {
-        return $this->renderElement($env, $context, $view, ElementInterface::TYPE_VIEW, $variables);
-    }
-
     public function carousel(Environment $env, array $context, ?string $carousel, array $variables = []): string
     {
         return $this->renderElement($env, $context, $carousel, ElementInterface::TYPE_CAROUSEL, $variables);
+    }
+
+    public function view(Environment $env, array $context, ?string $view, array $variables = []): string
+    {
+        return $this->renderElement($env, $context, $view, ElementInterface::TYPE_VIEW, $variables);
     }
 
     public function linkToRoute(

--- a/tests/Application/templates/bundles/SyliusShopBundle/layout.html.twig
+++ b/tests/Application/templates/bundles/SyliusShopBundle/layout.html.twig
@@ -32,6 +32,7 @@
         {{ sscms_block('sylius_channel') }}
 
         {{ sscms_view('header') }}
+        {{ sscms_asset('image') }}
         {% block header %}
             <header>
                 {{ sylius_template_event('sylius.shop.layout.header') }}


### PR DESCRIPTION
This PR adds the Twig function `sscms_asset` which will render an asset. Only images are supported by now.