### PR TITLE
Create an empty template when an element doesn't exist

### DIFF
--- a/src/Exception/NonExistingElementException.php
+++ b/src/Exception/NonExistingElementException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusCMSPlugin\Exception;
+
+use Setono\SyliusCMSPlugin\Twig\LogicalTemplateName;
+use Twig\Error\LoaderError;
+
+/**
+ * This exception is thrown when an element is not found in the database
+ *
+ * @internal
+ */
+final class NonExistingElementException extends LoaderError
+{
+    public static function fromLogicalTemplateName(LogicalTemplateName $logicalTemplateName): self
+    {
+        return new self(
+            sprintf(
+                'Element with type "%s" and code "%s" does not exist',
+                $logicalTemplateName->type,
+                $logicalTemplateName->code,
+            ),
+        );
+    }
+}

--- a/src/Resources/config/services/twig.xml
+++ b/src/Resources/config/services/twig.xml
@@ -11,7 +11,7 @@
                  class="Setono\SyliusCMSPlugin\Twig\Loader\TemplateLoader">
             <argument type="service" id="setono_sylius_cms.repository.template"/>
 
-            <tag name="twig.loader"/>
+            <tag name="twig.loader" priority="-100"/>
         </service>
 
         <service id="setono_sylius_cms.twig.extension"
@@ -43,7 +43,11 @@
             <argument type="service" id="setono_sylius_cms.generator.twig.composite"/>
             <argument>asset</argument>
 
-            <tag name="twig.loader"/>
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
+
+            <tag name="twig.loader" priority="-70"/>
         </service>
 
         <service id="setono_sylius_cms.twig.loader.element_loader.block"
@@ -52,7 +56,11 @@
             <argument type="service" id="setono_sylius_cms.generator.twig.composite"/>
             <argument>block</argument>
 
-            <tag name="twig.loader"/>
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
+
+            <tag name="twig.loader" priority="-60"/>
         </service>
 
         <service id="setono_sylius_cms.twig.loader.element_loader.carousel"
@@ -61,7 +69,11 @@
             <argument type="service" id="setono_sylius_cms.generator.twig.composite"/>
             <argument>carousel</argument>
 
-            <tag name="twig.loader"/>
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
+
+            <tag name="twig.loader" priority="-80"/>
         </service>
 
         <service id="setono_sylius_cms.twig.loader.element_loader.page"
@@ -70,7 +82,11 @@
             <argument type="service" id="setono_sylius_cms.generator.twig.composite"/>
             <argument>page</argument>
 
-            <tag name="twig.loader"/>
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
+
+            <tag name="twig.loader" priority="-90"/>
         </service>
     </services>
 </container>

--- a/src/Twig/Loader/GenericElementLoader.php
+++ b/src/Twig/Loader/GenericElementLoader.php
@@ -6,6 +6,10 @@ namespace Setono\SyliusCMSPlugin\Twig\Loader;
 
 use Exception;
 use InvalidArgumentException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Setono\SyliusCMSPlugin\Exception\NonExistingElementException;
 use Setono\SyliusCMSPlugin\Generator\Twig\TwigGeneratorInterface;
 use Setono\SyliusCMSPlugin\Model\Element;
 use Setono\SyliusCMSPlugin\Model\ElementInterface;
@@ -16,8 +20,10 @@ use Twig\Loader\LoaderInterface;
 use Twig\Source;
 use Webmozart\Assert\Assert;
 
-final class GenericElementLoader implements LoaderInterface
+final class GenericElementLoader implements LoaderInterface, LoggerAwareInterface
 {
+    private LoggerInterface $logger;
+
     /** @var array<string, ElementInterface> */
     private array $cache = [];
 
@@ -30,6 +36,7 @@ final class GenericElementLoader implements LoaderInterface
     ) {
         Assert::oneOf($supportsType, Element::getTypes());
         $this->supportsType = $supportsType;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -71,7 +78,17 @@ final class GenericElementLoader implements LoaderInterface
     {
         $logicalTemplateName = LogicalTemplateName::createFromString($name);
 
-        $element = $this->getElement($logicalTemplateName);
+        try {
+            $element = $this->getElement($logicalTemplateName);
+        } catch (NonExistingElementException) {
+            $this->logger->error(sprintf(
+                'Element with type "%s" and code "%s" does not exist',
+                $logicalTemplateName->type,
+                $logicalTemplateName->code,
+            ));
+
+            return new Source('', (string) $logicalTemplateName);
+        }
 
         return new Source($this->twigGenerator->generate($element, [
             'channelCode' => $logicalTemplateName->channelCode,
@@ -80,6 +97,8 @@ final class GenericElementLoader implements LoaderInterface
     }
 
     /**
+     * todo shouldn't this method just return true always?
+     *
      * @param string $name
      * @param int $time
      */
@@ -89,7 +108,6 @@ final class GenericElementLoader implements LoaderInterface
 
         $element = $this->getElement($logicalTemplateName);
 
-        /** @psalm-suppress PossiblyNullReference */
         $updatedAt = $element->getUpdatedAt();
         if (null === $updatedAt) {
             return false;
@@ -99,7 +117,8 @@ final class GenericElementLoader implements LoaderInterface
     }
 
     /**
-     * @throws LoaderError when the logical template name does not exist, the database connection isn't there or the respective tables hasn't been created yet
+     * @throws NonExistingElementException when the logical template name does not exist
+     * @throws LoaderError when the database connection isn't there or the respective tables hasn't been created yet
      */
     private function getElement(LogicalTemplateName $logicalTemplateName): ElementInterface
     {
@@ -120,15 +139,17 @@ final class GenericElementLoader implements LoaderInterface
             }
 
             if (null === $element) {
-                throw new LoaderError(sprintf(
-                    'The logical template name "%s" does not exist',
-                    (string) $logicalTemplateName,
-                ));
+                throw NonExistingElementException::fromLogicalTemplateName($logicalTemplateName);
             }
 
             $this->cache[$logicalTemplateName->value] = $element;
         }
 
         return $this->cache[$logicalTemplateName->value];
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 }

--- a/src/Twig/Loader/TemplateLoader.php
+++ b/src/Twig/Loader/TemplateLoader.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusCMSPlugin\Twig\Loader;
 use Exception;
 use Setono\SyliusCMSPlugin\Model\TemplateInterface;
 use Setono\SyliusCMSPlugin\Repository\TemplateRepositoryInterface;
+use Setono\SyliusCMSPlugin\Twig\LogicalTemplateName;
 use Twig\Error\LoaderError;
 use Twig\Loader\LoaderInterface;
 use Twig\Source;
@@ -35,7 +36,13 @@ final class TemplateLoader implements LoaderInterface
      */
     public function exists($name): bool
     {
-        return null !== $this->findTemplate($name);
+        try {
+            LogicalTemplateName::createFromString($name);
+
+            return false;
+        } catch (\InvalidArgumentException) {
+            return null !== $this->findTemplate($name);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR will detect when an element is requested that doesn't exist in the database and create an empty template in place of that element. This has the benefit that:

1. We will not query the database each time we see the missing element
2. We will not spam our error reporting